### PR TITLE
Updating workflow for ready and done

### DIFF
--- a/docs/workflow-guidelines.md
+++ b/docs/workflow-guidelines.md
@@ -18,6 +18,7 @@
   - team communication
 - Google Drive
   - sharing documents
+  - links to content developed in other platforms
 
 ## Agile
 
@@ -40,7 +41,7 @@ Team members can only work on tasks currently **assigned** to them. Any changes 
 
 With your daily standup completed with the Geekbot, also move along your tasks on the board.
 
-### Project board
+## Project board
 
 Our project board has the following **columns**:
 
@@ -53,24 +54,59 @@ Our project board has the following **columns**:
   - Awaiting Review
   - Done
 
-When a task is moved to *Awaiting Review* or *Done*, a short closing **message** should be added to the issue. When a task is moved to *Awaiting Review*, one or more team members to do the review should be contacted directly, or a general request is made in the daily as a blocker.
-
-### Technicalities
-
 All board items are issues on github. Each item has one label in capital letters setting its **level**: *EPIC*, *STORY* or *TASK*. 
 
-For each story to be ready, it needs the statement of the user story and a list of all associated tasks in the body of the issue. GitHub automatically **tracks** the progress of the story as these tasks are completed. To view this quickly also on the board, we add a label #x to the story and all associated tasks, with x being the issue number of the story.
+In addition, all tasks have at least one **component** label. These help structure the board and our issues thematically. Our components are *\*admin*, *\*backend*, *\*design* and *\*documentation*, *\*frontend* and *\*learning*. Stories do not have component labels, as they may contain various tasks.
 
-For convenience, tasks may have simple **subtasks** in their body, but which cannot be issues themselves. If that would be the case, the task should be split up.
+**Filtering** the board can be done quickly by clicking on a label, a milestone, or an assignee. Unfiltering can be done by clicking on the same again.
 
-In addition, we use **component** labels. These help structure the board and our issues thematically. We start with the labels *\*admin*, *\*backend*, *\*design* and *\*frontend*.
+### Definition of Ready
 
-Each task is assigned one or more team members, otherwise it is tagged *not assigned*.
+An issue is **ready** to be added to the product backlog as a story, when:
+- [ ] It has a title.
+- [ ] It has the label *STORY*.
+- [ ] It has a user story stating the goal (*why*).
+- [ ] The tasks are defined, i.e. the steps needed to reach that goal (*how*). At this point they are in Markdown only, not yet converted to issues.
+- [ ] The output is described (*what*).
+- [ ] The review process is described.
+- [ ] Optional: Specific acceptance criteria are stated.
 
-Filtering the board can be done quickly by clicking on a label, a milestone, or an assignee. Unfiltering can be done by clicking on the same again.
+### Adding stories to the sprint
 
-An issue is only **closed** when the task is moved to *Done*.
+When a story is added to the next sprint and moved to the sprint backlog, the following steps have to be done:
+- [ ] It gets the label *#x* with x the issue number, in #CCCCCC.
+- [ ] The milestone is set (*when*).
+- [ ] The main accountable team member is assigned (*who*).
+- [ ] The tasks are converted to individual issues and added to the "Next In" column.
 
-### Features
+Each of these tasks
+- [ ] has the following labels 
+  - [ ] "TASK"
+  - [ ] "*component" with a component from the available labels
+  - [ ] "#x" inherited from the story
+- [ ] has a team member assigned (may differ from the team member assigned to the story; if no team member is assigned it is labeled *not assigned* and the team is contacted on Slack about this)
+- [ ] inherits the milestone
+- [ ] optional: specific acceptance criteria
+- [ ] optional: subtasks in Markdown
 
-*tbd*
+Tracking: GitHub automatically **tracks** the progress of the story as these tasks are completed. To view all tasks belonging to one story quickly by filtering the board, we add the label *#x* to the story and all associated tasks, with x being the issue number of the story.
+
+### Reviewing and closing tasks
+
+A task is moved to the column **done**, when:
+- [ ] A closing message has been added to the issue about the output created.
+- [ ] The output has been broadcast on Slack.
+- [ ] The issue is closed.
+- [ ] Specific acceptance criteria (if any) are met.
+
+Some tasks require a **review** step before being done. This review process has been planned in the story, such that it incurs no delay. There are two main options:
+1. A specific team member is assigned to do the review and is notified. The initial assignee adds a review message to the issue about the output already created and the expectation from the review. Then, the reviewer performs the closing steps when the review has been completed.
+2. Feedback is requested from the whole team on Slack with a time limit. After this time limit has passed, the initial assignee performs the closing steps.
+
+### Closing stories
+
+Stories are closed after the sprint meeting, when
+- [ ] All individual tasks have been closed.
+- [ ] They were mentioned and discussed in the sprint retrospective.
+- [ ] All output has been published (*to be defined*).
+


### PR DESCRIPTION
The criteria for stories and tasks to be ready, and before closing to be done, as well as a statement on the review process have been added.

Still open: publication process of non-code output